### PR TITLE
fix(esp32): pin daliMaster loop task to core 1 with elevated priority

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,12 @@ void setup()
     setup0_ready = true;
 
     #ifdef ARDUINO_ARCH_ESP32
+    // Pin DALI loop to APP_CPU (core 1) with elevated priority so it is not
+    // preempted by WiFi/IP/Ethernet activity on PRO_CPU (core 0) nor by the
+    // Arduino loopTask. Without this, the RMT RX re-arm (Rmt.cpp) misses the
+    // backward-frame window during ETS-triggered scans → truncated frames
+    // (bits=6/7/0). Equivalent to the RP2040 setup1()/loop1() multicore fix
+    // (OFM-Dali commit fb3aea9).
     xTaskCreateUniversal([](void* parms) {
         while(!setup0_ready) {
             delay(10);
@@ -40,8 +46,10 @@ void setup()
         for (;;)
         {
             openknxDaliModule.loop1(knx.configured());
-        } 
-    }, "daliModuleLoop1", 8192, NULL, 0, nullptr, 0);
+            vTaskDelay(1);  // yield to lower-prio tasks on this core
+        }
+    }, "daliModuleLoop1", 8192, NULL, 5, nullptr, 1);
+    //                          ^prio=5  ^core=APP_CPU (opposite of WiFi/IP)
     #endif
 
     while(!setup1_ready) {


### PR DESCRIPTION
## Summary
Pin the ESP32 DALI master loop task to APP_CPU (core 1) and raise its priority,
so it is no longer preempted by WiFi/IP/Ethernet activity on PRO_CPU (core 0)
or starved at idle priority during KNX traffic.

## Problem
On ESP32, the `daliModuleLoop1` task was created via `xTaskCreateUniversal`
with **priority 0 (idle)** and pinned to **core 0**. Core 0 hosts the WiFi
and lwIP stacks, so the DALI master process was competing directly with
KNX/IP traffic on the same core. Under ETS activity this caused noticeable
preemption of the DALI processing loop.

The downstream symptom — together with the RX-task priority issue fixed in
[cad435/dali fix/rmt-rx-task-priority-core-pinning](https://github.com/cad435/dali/tree/fix/rmt-rx-task-priority-core-pinning) —
was that ETS-triggered DALI bus discovery returned truncated backward frames
(`bits=6/7/0`, data `0x3F/0x7F/0x00`) in the gateway's `daliMonitor` stream,
with roughly 35% of backward frames affected.